### PR TITLE
Add user to AliasPlugin migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## (unreleased)
-
+* fix: Use username field for looking up version user
 
 ## 0.0.2 (2023-07-11)
 * fix: Added the Github project url to the setup.py file for PyPi linking

--- a/djangocms_4_migration/management/commands/migrate_alias_plugins.py
+++ b/djangocms_4_migration/management/commands/migrate_alias_plugins.py
@@ -206,9 +206,11 @@ def process_old_alias_sources(site, language, site_plugin_queryset):
         if is_versioning_enabled():
             from djangocms_versioning.models import Version
             # Create version
-            changed_by = User.objects.get(username=old_plugin.placeholder.source.changed_by)
-            version = Version.objects.create(content=alias_content, created_by=changed_by)
-            version.save()
+            changed_by = User.objects.get(**{User.USERNAME_FIELD: old_plugin.placeholder.source.changed_by})
+            version = Version.objects.create(
+                content=alias_content,
+                created_by=changed_by
+            )
             version.publish(changed_by)
 
         # create csm4 alias plugins for cms3 alias references


### PR DESCRIPTION
`AliasPlugin` is also versioned and needs to be created with a `.with_user` now.