### PR TITLE
fix: Allow alias plugin migration also on MySql and Sqlite

### DIFF
--- a/djangocms_4_migration/management/commands/migrate_alias_plugins.py
+++ b/djangocms_4_migration/management/commands/migrate_alias_plugins.py
@@ -254,8 +254,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         with transaction.atomic():
             # Alias source plugin list
-            cms3_alias_ref_ids = AliasPluginModel.objects.values('plugin_id').order_by('plugin_id').distinct('plugin_id')
-            plugin_id_list = [cms3_plugin['plugin_id'] for cms3_plugin in cms3_alias_ref_ids if cms3_plugin['plugin_id']]
+            plugin_id_list = list(AliasPluginModel.objects.values_list('plugin_id', flat=True).order_by('plugin_id'))
             alias_source_total = len(plugin_id_list)
             # Alias references list count
             alias_reference_total = AliasPluginModel.objects.count()


### PR DESCRIPTION
The previous implementation raises an error on MySql:
```
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.9/site-packages/djangocms_4_migration/management/commands/migrate_alias_plugins.py", line 258, in handle
    plugin_id_list = [cms3_plugin['plugin_id'] for cms3_plugin in cms3_alias_ref_ids if cms3_plugin['plugin_id']]
  File "/usr/local/lib/python3.9/site-packages/django/db/models/query.py", line 398, in __iter__
    self._fetch_all()
  File "/usr/local/lib/python3.9/site-packages/django/db/models/query.py", line 1881, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/usr/local/lib/python3.9/site-packages/django/db/models/query.py", line 208, in __iter__
    for row in compiler.results_iter(
  File "/usr/local/lib/python3.9/site-packages/django/db/models/sql/compiler.py", line 1513, in results_iter
    results = self.execute_sql(
  File "/usr/local/lib/python3.9/site-packages/django/db/models/sql/compiler.py", line 1549, in execute_sql
    sql, params = self.as_sql()
  File "/usr/local/lib/python3.9/site-packages/django/db/models/sql/compiler.py", line 785, in as_sql
    distinct_result, distinct_params = self.connection.ops.distinct_sql(
  File "/usr/local/lib/python3.9/site-packages/django/db/backends/base/operations.py", line 202, in distinct_sql
    raise NotSupportedError(
django.db.utils.NotSupportedError: DISTINCT ON fields is not supported by this database backend
```

Distinctness does not have to be enforced since plugin id are distinct by database constraints.