### PR TITLE
migrate_alias_plugins: fall back to CMS_MIGRATION_USER_ID for missing…

### DIFF
--- a/djangocms_4_migration/management/commands/migrate_alias_plugins.py
+++ b/djangocms_4_migration/management/commands/migrate_alias_plugins.py
@@ -228,9 +228,15 @@ def process_old_alias_sources(site, language, site_plugin_queryset):
             from djangocms_versioning.models import Version
 
             # Create version
-            changed_by = User.objects.get(
+            changed_by = User.objects.filter(
                 **{User.USERNAME_FIELD: old_plugin.placeholder.source.changed_by}
-            )
+            ).first()
+            if changed_by is None:
+                # Fallback when the historical username no longer exists in the
+                # target DB. Uses the same CMS_MIGRATION_USER_ID setting that
+                # page_version_integration_data_migration already relies on.
+                from django.conf import settings
+                changed_by = User.objects.get(pk=settings.CMS_MIGRATION_USER_ID)
             version = Version.objects.create(
                 content=alias_content, created_by=changed_by
             )


### PR DESCRIPTION
… users

process_old_alias_sources() used User.objects.get(username=...) without a fallback, crashing with DoesNotExist whenever the historical changed_by username no longer exists in the target database. This is common when migrating a cloned production dump where old staff accounts have been removed.

Align with migrate_page_version_integration_data_migration, which uses the same CMS_MIGRATION_USER_ID settings fallback pattern.

Encountered during OFAW-216 (ofa-webshop Django 5 + cms 4 upgrade) against a production clone; ~3 unique usernames triggered the crash after the page/version migration had already completed successfully.